### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/532140660867/cf3bf8b8-d896-4fcd-b550-a2d676756ab8/6b9120da-da42-473e-9fb5-a4126a87cfba/_apis/work/boardbadge/de6ca9f7-cbae-45aa-93b5-4e880f7fc1c5)](https://dev.azure.com/532140660867/cf3bf8b8-d896-4fcd-b550-a2d676756ab8/_boards/board/t/6b9120da-da42-473e-9fb5-a4126a87cfba/Microsoft.RequirementCategory)
 The Courses
 ==============================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/532140660867/cf3bf8b8-d896-4fcd-b550-a2d676756ab8/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.